### PR TITLE
CO: Allow tricky CSS on HTML content

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3348,6 +3348,7 @@ exit;
 
                 $config->set('Attr.EnableID', true);
                 $config->set('HTML.Trusted', true);
+                $config->set('CSS.AllowTricky', true);
                 $config->set('Cache.SerializerPath', _PS_CACHE_DIR_.'purifier');
                 $config->set('Attr.AllowedFrameTargets', array('_blank', '_self', '_parent', '_top'));
                 if (is_array($uri_unescape)) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | Use the "develop" branch if you target PrestaShop 1.7; use the "1.6.1.x" branch if you target PrestaShop 1.6 (bugfixes only). |
| Description? | No specific configuration is needed. The problem is present from a longtime ago. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Does it break backward compatibility? no |
| Deprecations? | Does it deprecate an existing feature? no |
| Fixed ticket? | N/A |
| How to test? | Try to center an image in CMS content. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

In CMS content, it is not possible to center an image because "display: block" css property is removed when saving the CMS content from the Back office.
